### PR TITLE
use setuptools to retrieve the version from sources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: ocrd_physical_import.__version__

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,11 @@ import codecs
 
 import setuptools
 from setuptools import setup
-from ocrd_physical_import import __version__
 
 install_requires = open('requirements.txt').read().split('\n')
 
 setup(
     name='browse-ocrd-physical-import',
-    version=__version__,
     author='Johannes Künsebeck',
     author_email='kuensebeck@googlemail.com',
     description='Plugin for browse-ocrd to scan book pages with an android phone camera',


### PR DESCRIPTION
Fix #1 

(recipe from [here](https://packaging.python.org/guides/single-sourcing-package-version/))